### PR TITLE
style: refine description of opencode-em-os in local models article

### DIFF
--- a/src/data/post/mid-weight-llms-futuro.mdx
+++ b/src/data/post/mid-weight-llms-futuro.mdx
@@ -90,7 +90,7 @@ Cabe destacar que este es el principal trade-off del enfoque puramente local. Si
 
 Nada de esto tendría sentido sin una herramienta _vendor-agnostic_. Utilizo **OpenCode porque no me ata a un proveedor ni a una suscripción**. Me permite combinar diferentes orígenes de modelos y orquestar estos flujos complejos con total libertad. Además, es open-source y auditable, con todas las ventajas que ello conlleva.
 
-Si creemos que el futuro es local o mixto, OpenCode es, en mi opinión, uno de los actores principales para recuperar la soberanía sobre nuestras herramientas. De hecho, estoy trabajando en configuraciones que van más allá del puro desarrollo, como este <a href="https://github.com/apenlor/opencode-em-os" target="_blank" rel="noopener noreferrer">asistente de soporte para Engineering Managers</a> integrado con Jira y GitHub.
+Si creemos que el futuro es local o mixto, OpenCode es, en mi opinión, uno de los actores principales para recuperar la soberanía sobre nuestras herramientas. De hecho, estoy trabajando en configuraciones que van más allá del puro desarrollo, como este <a href="https://github.com/apenlor/opencode-em-os" target="_blank" rel="noopener noreferrer">asistente de soporte para Engineering Managers</a> integrado con Jira y GitHub (una adaptación nativa para OpenCode, con funcionalidades personalizadas, basada en el repositorio original de Julio César Pérez para Claude: <a href="https://github.com/jcesarperez/claude-em" target="_blank" rel="noopener noreferrer">claude-em</a>).
 
 #### Repositorios de referencia
 


### PR DESCRIPTION
Refines the description of the opencode-em-os repository in the 'Mid-weight LLMs' article to explicitly highlight its nature as a native adaptation for OpenCode with custom features.