### PR TITLE
feat(about): merge principal roles into a single entry

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -211,16 +211,9 @@ const certifications = [
     items={[
       {
         title:
-          'Principal Engineer — Product & Platform Architecture <br /> <span class="font-normal">Sngular · A Coruña, Spain</span> <br /> <span class="text-sm font-normal">2025 - Present</span>',
+          'Principal Engineer | Chapter Lead <br /> <span class="font-normal">Sngular · A Coruña, Spain</span> <br /> <span class="text-sm font-normal">Aug 2024 - Present</span>',
         description:
-          "Head engineering for a joint venture product on GCP. Designing observability and platform capabilities for high-throughput distributed systems.",
-        icon: "tabler:briefcase",
-      },
-      {
-        title:
-          'Principal Engineer — Chapter Lead Backend & QE <br /> <span class="font-normal">Sngular · A Coruña, Spain</span> <br /> <span class="text-sm font-normal">2024 - 2025</span>',
-        description:
-          "Led Backend & QE chapters across teams. Partnered with presales on technical solutions and defined career paths and training programs.",
+          "Lead engineering for a joint venture product, defining platform architecture, observability, and modernization strategy on GCP. Also lead Backend & QE chapters, driving technical standards, career growth, staffing, and presales support across teams.",
         icon: "tabler:briefcase",
       },
       {


### PR DESCRIPTION
## Summary
- Merged the two separate Sngular principal-role entries into a single "Principal Engineer | Chapter Lead" entry.
- Updated dates to "Aug 2024 - Present" and combined the descriptions for product/platform architecture and chapter leadership.
- Aligned the Work Experience section with the simplified LinkedIn profile.